### PR TITLE
Add register_addon method

### DIFF
--- a/pycclib/version.py
+++ b/pycclib/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.5.4'
+__version__ = '1.5.5'


### PR DESCRIPTION
Registering addons is currently done via setting an environment variable
for the endpoint and using kensa. The logic is also implemented in some
of our components to register addons on the bootstrap process.
cloud&heat use a concatenation of tenant_name and email for the login,
this breaks the kensa tool.

This commit simplifies the register process in our components and enables
us to add the register addon functionality in the cctrl/exo/dotcloudng/cnh.
